### PR TITLE
Fetch feature flags from flags.mineskin.org with Flagsmith fallback

### DIFF
--- a/plugins/flagsmith.ts
+++ b/plugins/flagsmith.ts
@@ -1,6 +1,6 @@
 import { defineNuxtPlugin } from "#app";
 import flagsmith from 'flagsmith'
-import type { GetValueOptions, HasFeatureOptions, IFlagsmith, IState } from "flagsmith/types";
+import type { GetValueOptions, HasFeatureOptions, IFlagsmith } from "flagsmith/types";
 
 interface ClientFlagEntry {
     key: string;
@@ -19,32 +19,53 @@ const MINESKIN_FLAGS_URL = 'https://flags.mineskin.org/flags/client.json';
 const FLAGSMITH_PROXY_API = 'https://flagsmith-proxy-worker.inventive.workers.dev/';
 const FETCH_TIMEOUT_MS = 3000;
 
-function bundleToFlagsmithState(bundle: ClientFlagsBundle, environmentID: string): IState {
-    const flags: Record<string, { id: number; enabled: boolean; value: boolean | number | string | null }> = {};
-    bundle.flags.forEach((entry, i) => {
-        flags[entry.key] = {
-            id: i + 1,
-            enabled: entry.enabled,
-            value: entry.type === 'boolean' ? null : entry.value
-        };
-    });
-    return {
-        api: MINESKIN_FLAGS_URL,
-        environmentID,
-        flags
-    } as unknown as IState;
-}
-
-async function fetchMineskinBundle(): Promise<ClientFlagsBundle> {
+async function fetchMineskinBundle(): Promise<ClientFlagsBundle | null> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
         const res = await fetch(MINESKIN_FLAGS_URL, { signal: controller.signal });
-        if (!res.ok) throw new Error(`flags.mineskin.org HTTP ${res.status}`);
+        if (!res.ok) throw new Error(`flags.mineskin.org HTTP ${ res.status }`);
         return await res.json();
+    } catch (e) {
+        console.warn('[flags] flags.mineskin.org unavailable, using Flagsmith only', e);
+        return null;
     } finally {
         clearTimeout(timer);
     }
+}
+
+function buildMergedFlags(bundle: ClientFlagsBundle | null): Map<string, ClientFlagEntry> {
+    const map = new Map<string, ClientFlagEntry>();
+    if (!bundle) return map;
+    for (const entry of bundle.flags) {
+        map.set(entry.key, entry);
+    }
+    return map;
+}
+
+function wrapFlagsmith(target: IFlagsmith, overrides: Map<string, ClientFlagEntry>): IFlagsmith {
+    if (overrides.size === 0) return target;
+    return new Proxy(target, {
+        get(t, prop, receiver) {
+            if (prop === 'hasFeature') {
+                return function (key: string, options?: HasFeatureOptions): boolean {
+                    if (overrides.has(key)) return overrides.get(key)!.enabled;
+                    return t.hasFeature(key, options);
+                };
+            }
+            if (prop === 'getValue') {
+                return function <T = any> (key: string, options?: GetValueOptions<T>, skipAnalytics?: boolean): any {
+                    if (overrides.has(key)) {
+                        const entry = overrides.get(key)!;
+                        return entry.type === 'boolean' ? null : entry.value;
+                    }
+                    return t.getValue(key, options, skipAnalytics);
+                };
+            }
+            const value = Reflect.get(t, prop, receiver);
+            return typeof value === 'function' ? value.bind(t) : value;
+        }
+    }) as IFlagsmith;
 }
 
 export default defineNuxtPlugin({
@@ -54,35 +75,23 @@ export default defineNuxtPlugin({
             const runtimeConfig = useRuntimeConfig();
             const environmentID = runtimeConfig.public.flagsmithEnvironment as string;
 
-            let initialised = false;
-            try {
-                const bundle = await fetchMineskinBundle();
-                await flagsmith.init({
-                    environmentID,
-                    api: MINESKIN_FLAGS_URL,
-                    enableLogs: true,
-                    preventFetch: true,
-                    state: bundleToFlagsmithState(bundle, environmentID)
-                });
-                initialised = true;
-            } catch (e) {
-                console.warn('[flags] flags.mineskin.org unavailable, falling back to Flagsmith', e);
-            }
+            const [bundle, state] = await Promise.all([
+                fetchMineskinBundle(),
+                fetch('/flagsmith.json').then(res => res.json())
+            ]);
 
-            if (!initialised) {
-                const state = await fetch('/flagsmith.json').then(res => res.json());
-                await flagsmith.init({
-                    environmentID,
-                    api: FLAGSMITH_PROXY_API,
-                    enableLogs: true,
-                    cacheFlags: true,
-                    state: state
-                });
-            }
+            await flagsmith.init({
+                environmentID,
+                api: FLAGSMITH_PROXY_API,
+                enableLogs: true,
+                cacheFlags: true,
+                state: state
+            });
 
+            const overrides = buildMergedFlags(bundle);
             return {
                 provide: {
-                    flags: flagsmith as IFlagsmith
+                    flags: wrapFlagsmith(flagsmith as IFlagsmith, overrides)
                 }
             };
         }

--- a/plugins/flagsmith.ts
+++ b/plugins/flagsmith.ts
@@ -1,20 +1,85 @@
 import { defineNuxtPlugin } from "#app";
 import flagsmith from 'flagsmith'
-import type { GetValueOptions, HasFeatureOptions, IFlagsmith } from "flagsmith/types";
+import type { GetValueOptions, HasFeatureOptions, IFlagsmith, IState } from "flagsmith/types";
+
+interface ClientFlagEntry {
+    key: string;
+    type: 'boolean' | 'number' | 'string';
+    value: boolean | number | string;
+    enabled: boolean;
+}
+
+interface ClientFlagsBundle {
+    generatedAt: string;
+    version: number;
+    flags: ClientFlagEntry[];
+}
+
+const MINESKIN_FLAGS_URL = 'https://flags.mineskin.org/flags/client.json';
+const FLAGSMITH_PROXY_API = 'https://flagsmith-proxy-worker.inventive.workers.dev/';
+const FETCH_TIMEOUT_MS = 3000;
+
+function bundleToFlagsmithState(bundle: ClientFlagsBundle, environmentID: string): IState {
+    const flags: Record<string, { id: number; enabled: boolean; value: boolean | number | string | null }> = {};
+    bundle.flags.forEach((entry, i) => {
+        flags[entry.key] = {
+            id: i + 1,
+            enabled: entry.enabled,
+            value: entry.type === 'boolean' ? null : entry.value
+        };
+    });
+    return {
+        api: MINESKIN_FLAGS_URL,
+        environmentID,
+        flags
+    } as unknown as IState;
+}
+
+async function fetchMineskinBundle(): Promise<ClientFlagsBundle> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+        const res = await fetch(MINESKIN_FLAGS_URL, { signal: controller.signal });
+        if (!res.ok) throw new Error(`flags.mineskin.org HTTP ${res.status}`);
+        return await res.json();
+    } finally {
+        clearTimeout(timer);
+    }
+}
 
 export default defineNuxtPlugin({
     name: 'flags',
     async setup(nuxtApp) {
         if (process.client) {
             const runtimeConfig = useRuntimeConfig();
-            const state = await fetch('/flagsmith.json').then(res => res.json());
-            await flagsmith.init({
-                environmentID: runtimeConfig.public.flagsmithEnvironment as string,
-                api: 'https://flagsmith-proxy-worker.inventive.workers.dev/',
-                enableLogs: true,
-                cacheFlags: true,
-                state: state
-            });
+            const environmentID = runtimeConfig.public.flagsmithEnvironment as string;
+
+            let initialised = false;
+            try {
+                const bundle = await fetchMineskinBundle();
+                await flagsmith.init({
+                    environmentID,
+                    api: MINESKIN_FLAGS_URL,
+                    enableLogs: true,
+                    preventFetch: true,
+                    state: bundleToFlagsmithState(bundle, environmentID)
+                });
+                initialised = true;
+            } catch (e) {
+                console.warn('[flags] flags.mineskin.org unavailable, falling back to Flagsmith', e);
+            }
+
+            if (!initialised) {
+                const state = await fetch('/flagsmith.json').then(res => res.json());
+                await flagsmith.init({
+                    environmentID,
+                    api: FLAGSMITH_PROXY_API,
+                    enableLogs: true,
+                    cacheFlags: true,
+                    state: state
+                });
+            }
+
             return {
                 provide: {
                     flags: flagsmith as IFlagsmith


### PR DESCRIPTION
Loads the client flag bundle published to R2 (flags.mineskin.org/flags/client.json) and initialises Flagsmith with preventFetch so the SDK stays as the consumer API while the new MongoDB-backed flag service is the source of truth. Falls back to the existing Flagsmith proxy worker flow if the R2 fetch fails or times out.