### PR TITLE
auto-link anonymous skins to user after sign-in

### DIFF
--- a/api/MineSkinAPI.ts
+++ b/api/MineSkinAPI.ts
@@ -11,6 +11,7 @@ import type { CapeListResponse } from "~/types/CapeListResponse";
 import type { GenerateOptions } from "~/types/GenerateOptions";
 import type { GenerateResponse } from "~/types/GenerateResponse";
 import type { SkinUser } from "~/types/SkinUser";
+import { useSkinStore } from "~/stores/skins";
 
 const INIT: RequestInit = {
     headers: {
@@ -382,6 +383,15 @@ export class MineSkinAPI {
             });
         }
 
+        public async linkAnonymous(anonId: string): Promise<MineSkinResponse<'misc', { linked: number }>> {
+            return this.api.request(`/v2/me/link-anonymous`, {
+                ...INIT,
+                method: 'POST',
+                credentials: 'include',
+                body: JSON.stringify({ anonId })
+            });
+        }
+
     }(this);
 
     public stats = new class {
@@ -402,10 +412,24 @@ export class MineSkinAPI {
         if (this.authed) {
             baseInit.credentials = init?.credentials ?? 'include';
         }
-        return fetch(`${ this.BASE }${ path }`, {
+
+        const merged: RequestInit = {
             ...baseInit,
             ...init
-        })
+        };
+        if (!this.authed && (path.startsWith('/v2/generate') || path.startsWith('/v2/queue'))) {
+            try {
+                const skinStore = useSkinStore();
+                merged.headers = {
+                    ...(merged.headers as Record<string, string> | undefined),
+                    'MineSkin-Anon-Id': skinStore.ensureAnonId()
+                };
+            } catch (e) {
+                console.warn('Failed to attach anon id', e);
+            }
+        }
+
+        return fetch(`${ this.BASE }${ path }`, merged)
             .then(res => this.handleResponse(res, options));
     }
 

--- a/stores/auth.ts
+++ b/stores/auth.ts
@@ -7,7 +7,7 @@ const TOKEN_TIMEOUT = 1000 * 60 * 45;
 
 export const useAuthStore = defineStore('auth', () => {
     const config = useRuntimeConfig();
-    const {$mineskin, $account} = useNuxtApp();
+    const {$mineskin, $account, $flags} = useNuxtApp();
 
     const router = useRouter();
 
@@ -144,6 +144,7 @@ export const useAuthStore = defineStore('auth', () => {
     }
 
     const linkAnonymousSkins = () => {
+        if (!$flags.hasFeature('web.anon_link.enabled')) return;
         const skinStore = useSkinStore();
         const anonId = skinStore.anonId;
         if (!anonId) return;

--- a/stores/auth.ts
+++ b/stores/auth.ts
@@ -1,6 +1,7 @@
 import type { Ref } from "vue";
 import type { AuthStatus } from "~/types/auth";
 import * as Sentry from "@sentry/browser"
+import { useSkinStore } from "~/stores/skins";
 
 const TOKEN_TIMEOUT = 1000 * 60 * 45;
 
@@ -105,6 +106,7 @@ export const useAuthStore = defineStore('auth', () => {
             } catch (e) {
                 console.error(e);
             }
+            linkAnonymousSkins();
             return _user.value;
         }
 
@@ -139,6 +141,24 @@ export const useAuthStore = defineStore('auth', () => {
         }
         lastApiTokenRefresh.value = Date.now() - TOKEN_TIMEOUT + 5000;
         return false;
+    }
+
+    const linkAnonymousSkins = () => {
+        const skinStore = useSkinStore();
+        const anonId = skinStore.anonId;
+        if (!anonId) return;
+        $mineskin.me.linkAnonymous(anonId)
+            .then(res => {
+                if (res && !(res as any)?.errors?.length) {
+                    skinStore.clearAnonId();
+                }
+            })
+            .catch(e => {
+                console.error('Failed to link anonymous skins', e);
+                try {
+                    Sentry.captureException(e);
+                } catch {}
+            });
     }
 
     const getWebTokenCookie = (): string | undefined => {

--- a/stores/skins.ts
+++ b/stores/skins.ts
@@ -5,6 +5,7 @@ export const useSkinStore = defineStore('skins', () => {
 
     const mySkins = ref<string[]>([]);
     const legacySkins = ref<string[]>([]);
+    const anonId = ref<string | null>(null);
 
     const addSkin = (skinId: string) => {
         if (!mySkins.value.includes(skinId)) {
@@ -24,11 +25,25 @@ export const useSkinStore = defineStore('skins', () => {
         }
     }
 
+    const ensureAnonId = (): string => {
+        if (!anonId.value) {
+            anonId.value = crypto.randomUUID().replace(/-/g, '');
+        }
+        return anonId.value;
+    }
+
+    const clearAnonId = () => {
+        anonId.value = null;
+    }
+
     return {
         mySkins,
         legacySkins,
+        anonId,
         addSkin,
-        addLegacySkin
+        addLegacySkin,
+        ensureAnonId,
+        clearAnonId
     }
 
 }, {


### PR DESCRIPTION
Mint a per-browser anonId on the first anonymous /v2/generate, send it
via MineSkin-Anon-Id header, and POST it to /v2/me/link-anonymous after
sign-in succeeds so skins generated while logged out get claimed by the
account.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>